### PR TITLE
Add pinned versioning for wasmpack

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: '1.64.0'
+          toolchain: '1.86.0'
 
       - name: Checkout site repo
         uses: actions/checkout@v3

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.13.3'
 
       - name: Set up rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: '1.63.0'
+          toolchain: '1.64.0'
 
       - name: Checkout site repo
         uses: actions/checkout@v3

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Set up rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: '1.63.0'
+
       - name: Checkout site repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -44,7 +44,6 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Install wasm-pack
-        working-directory: ./site
         env:
           VERSION: 'v0.13.1'
         run: curl https://raw.githubusercontent.com/rustwasm/wasm-pack/refs/heads/master/docs/_installer/init.sh -sSf | sh

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -40,7 +40,9 @@ jobs:
 
       - name: Install wasm-pack
         working-directory: ./site
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        env:
+          VERSION: 'v0.13.1'
+        run: curl https://raw.githubusercontent.com/rustwasm/wasm-pack/refs/heads/master/docs/_installer/init.sh -sSf | sh
 
       - name: Run deploy script
         working-directory: ./site

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -10,6 +10,11 @@ jobs:
         with:
           node-version:  18.x
 
+      - name: Set up rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: '1.63.0'
+
       - name: Checkout branch
         uses: actions/checkout@v3
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: '1.64.0'
+          toolchain: '1.86.0'
 
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: '1.63.0'
+          toolchain: '1.64.0'
 
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -14,7 +14,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        working-directory: ./site
+        env:
+          VERSION: 'v0.13.1'
+        run: curl https://raw.githubusercontent.com/rustwasm/wasm-pack/refs/heads/master/docs/_installer/init.sh -sSf | sh
 
       - name: Build site
         working-directory: ./site

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install wasm-pack
-        working-directory: ./site
         env:
           VERSION: 'v0.13.1'
         run: curl https://raw.githubusercontent.com/rustwasm/wasm-pack/refs/heads/master/docs/_installer/init.sh -sSf | sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: '3.13.3'
 
       - name: Install pip requirements
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: '1.64.0'
+          toolchain: '1.86.0'
 
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: '1.86.0'
+          components: 'clippy'
 
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: '1.63.0'
+          toolchain: '1.64.0'
 
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,11 @@ jobs:
         with:
           node-version:  18.x
 
+      - name: Set up rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: '1.63.0'
+
       - name: Checkout branch
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,6 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Install wasm-pack
-        working-directory: ./site
         env:
           VERSION: 'v0.13.1'
         run: curl https://raw.githubusercontent.com/rustwasm/wasm-pack/refs/heads/master/docs/_installer/init.sh -sSf | sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,10 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        working-directory: ./site
+        env:
+          VERSION: 'v0.13.1'
+        run: curl https://raw.githubusercontent.com/rustwasm/wasm-pack/refs/heads/master/docs/_installer/init.sh -sSf | sh
 
       - name: Run JS linter
         working-directory: ./site

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.13.3'
 
       - name: Install pip requirements
         run: |
@@ -71,7 +71,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: '3.13.3'
 
       - name: Install pip requirements
         run: |
@@ -133,7 +133,7 @@ jobs:
   #     - name: Set up Python
   #       uses: actions/setup-python@v4
   #       with:
-  #         python-version: '3.11'
+  #         python-version: '3.13.3'
 
   #     - name: Set up Rust
   #       uses: actions-rs/toolchain@v1
@@ -170,7 +170,7 @@ jobs:
   #     - name: Set up python
   #       uses: actions/setup-python@v4
   #       with:
-  #         python-version: '3.11'
+  #         python-version: '3.13.3'
 
   #     - name: Install pip requirements
   #       run: |
@@ -197,7 +197,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.13.3'
 
       - name: Install pip requirements
         run: |
@@ -225,7 +225,7 @@ jobs:
   #     - name: Set up python
   #       uses: actions/setup-python@v4
   #       with:
-  #         python-version: '3.11'
+  #         python-version: '3.13.3'
 
   #     - name: Install pip requirements
   #       run: |
@@ -259,7 +259,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.13.3'
 
       - name: Install pip requirements
         run: |
@@ -286,7 +286,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.13.3'
 
       - name: Intall pip requirements
         run: |
@@ -418,7 +418,7 @@ jobs:
   #     - name: Set up python
   #       uses: actions/setup-python@v4
   #       with:
-  #         python-version: "3.11"
+  #         python-version: '3.13.3'
 
   #     - name: Install pip requirements
   #       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,11 @@ jobs:
         with:
           node-version:  18.x
 
+      - name: Set up rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: '1.63.0'
+
       - name: Checkout branch
         uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: '1.64.0'
+          toolchain: '1.86.0'
 
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: '1.63.0'
+          toolchain: '1.64.0'
 
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        working-directory: ./site
+        env:
+          VERSION: 'v0.13.1'
+        run: curl https://raw.githubusercontent.com/rustwasm/wasm-pack/refs/heads/master/docs/_installer/init.sh -sSf | sh
 
       - name: Yarn install
         working-directory: ./site

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install wasm-pack
-        working-directory: ./site
         env:
           VERSION: 'v0.13.1'
         run: curl https://raw.githubusercontent.com/rustwasm/wasm-pack/refs/heads/master/docs/_installer/init.sh -sSf | sh

--- a/scrapers/requirements.txt
+++ b/scrapers/requirements.txt
@@ -1,7 +1,7 @@
-aiohttp==3.9.1
-beautifulsoup4==4.11.1
-lxml==4.9.2
-requests==2.31.0
-tqdm==4.64.1
-datadog==0.44.0
-black==23.11.0
+aiohttp==3.12.12
+beautifulsoup4==4.13.4
+lxml==5.4.0
+requests==2.32.4
+tqdm==4.67.1
+datadog==0.51.0
+black==25.1.0

--- a/scrapers/sis_scraper/main.py
+++ b/scrapers/sis_scraper/main.py
@@ -359,10 +359,8 @@ async def scrape_term(term):
     # Replace all the dateStart/dateEnd with the MM/DD format used by the quacs frontend
     # Additionally, split out the prereq field into a separate json
     prerequisites = {}
-    date_to_quacs = (
-        lambda date: f"{str(date.month).zfill(2)}/{str(date.day).zfill(2)}"
-        if date != None
-        else ""
+    date_to_quacs = lambda date: (
+        f"{str(date.month).zfill(2)}/{str(date.day).zfill(2)}" if date != None else ""
     )
     for dept in courses:
         for course in dept["courses"]:

--- a/site/src/quacs-rs/src/test_context.rs
+++ b/site/src/quacs-rs/src/test_context.rs
@@ -15,7 +15,7 @@ fn get_sorted_schedules<'a, const N: usize>(ctx: &mut Context<'a, N>) -> Vec<Vec
     (0..num_schedules)
         .map(|i| {
             ctx.get_schedule(i)
-                .into_iter()
+                .iter()
                 .copied()
                 .collect::<BTreeSet<u32>>()
                 .into_iter()


### PR DESCRIPTION
Currently the wasmpack install doesn't have a version specified. I set a pinned version in this PR. This is intended to prevent issues if a newer version of wasmpack unexpectedly breaks out setup.